### PR TITLE
[40기 배효빈] ADD: 로그인, 회원가입 페이지에서 nav bar 안보이게 조건 구현

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -1,16 +1,20 @@
 import React, { useState, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import SideModal from '../../components/SideModal/SideModal';
 import NavSearchList from './NavSearchList';
 import useOnOutSideClick from '../../hooks/useOnOutSideClick';
 import './nav.scss';
 
+const interruptedRoute = ['signup', 'login'];
+
 const Nav = () => {
+  const { pathname } = useLocation();
   const [isClicked, setIsClicked] = useState(false);
   const [isFocus, setIsFocus] = useState(false);
   const navigate = useNavigate();
   const ref = useRef();
+  const isHideNav = interruptedRoute.some(path => pathname.includes(path));
 
   const onClickHandler = () => {
     setIsClicked(true);
@@ -21,6 +25,8 @@ const Nav = () => {
   };
 
   useOnOutSideClick(ref, () => setIsClicked(false));
+
+  if (isHideNav) return;
 
   return (
     <nav className="nav">


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
-  useLocation 이용해 로그인, 회원가입 페이지에서 navigation bar 보이지 않도록 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인, 회원가입 페이지에서 navigation bar 보이지 않도록 구현
- 로그인, 회원가입 pathname을 interruptedRoute 배열에 할당
- useLocation으로 현재 URL pathname 가져와 구조분해할당
- interruptedRouted 배열의 값에 some 메서드 이용해 pathname과 같은 값이 하나라도 존재하면 nav에서 반환되는 값이 없도록
 return
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- some 메서드 사용법 이해
- useLocation 이해

<br />

## :: 기타 질문 및 특이 사항

